### PR TITLE
Uptake context

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,7 +48,9 @@ func newCmdBrev() *cobra.Command {
 	brevCommand := &cobra.Command{
 		Use: "brev",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			fmt.Print("\n")
 			cmdContext.Init(verbose)
+
 		},
 	}
 

--- a/internal/brev_ctx/brev_ctx.go
+++ b/internal/brev_ctx/brev_ctx.go
@@ -360,11 +360,12 @@ func (c *RemoteContext) SetEndpoint(endpoint brev_api.Endpoint) (*brev_api.Endpo
 }
 
 // DeleteEndpoint removes the remote endpoint with the given ID.
-func (c *RemoteContext) DeleteEndpoint(endpoint brev_api.Endpoint) error {
-	_, err := c.agent.RemoveEndpoint(endpoint.Id)
+func (c *RemoteContext) DeleteEndpoint(epId string) error {
+	obj, err := c.agent.RemoveEndpoint(epId)
 	if err != nil {
 		return fmt.Errorf("failed to delete endpoint: %s", err)
 	}
+	fmt.Println(obj)
 	return nil
 }
 

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -27,6 +27,7 @@ import (
 	"github.com/brevdev/brev-go-cli/internal/cmdcontext"
 	"github.com/brevdev/brev-go-cli/internal/files"
 	"github.com/brevdev/brev-go-cli/internal/requests"
+	"github.com/fatih/color"
 )
 
 func addEndpoint(name string, context *cmdcontext.Context) error {
@@ -208,6 +209,9 @@ func runEndpoint(name string, method string, arg []string, jsonBody string, cont
 }
 
 func listEndpoints(context *cmdcontext.Context) error {
+
+	green := color.New(color.FgGreen).SprintFunc()
+
 	brevCtx, err := brev_ctx.New()
 	if err != nil {
 		return err
@@ -225,9 +229,9 @@ func listEndpoints(context *cmdcontext.Context) error {
 	})
 
 	// print
-	fmt.Fprintf(context.VerboseOut, "Endpoints in %s\n", project.Name)
+	fmt.Fprintf(context.VerboseOut, "Endpoints in %s:\n", project.Name)
 	for _, endpoint := range endpoints {
-		fmt.Fprintf(context.VerboseOut, "\t%s\n", endpoint.Name)
+		fmt.Fprintf(context.VerboseOut, "\t%s:\n", green(endpoint.Name))
 		fmt.Fprintf(context.VerboseOut, "\t%s%s\n\n", project.Domain, endpoint.Uri)
 	}
 

--- a/internal/env/command.go
+++ b/internal/env/command.go
@@ -99,7 +99,7 @@ func newCmdRemove(context *cmdcontext.Context) *cobra.Command {
 }
 
 // For shell completions, let the command raise an error
-// if something fails here, just return nil 
+// if something fails here, just return nil
 // i.e. don't provide completion but let user continue
 func getVariables() []string {
 	brevCtx, err := brev_ctx.New()

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -34,7 +34,7 @@ func logic(context *cmdcontext.Context) error {
 }
 
 func addVariable(name string, context *cmdcontext.Context) error {
-	
+
 	brevCtx, err := brev_ctx.New()
 	if err != nil {
 		return err

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -95,6 +95,24 @@ func ReadJSON(filepath string, v interface{}) error {
 	return json.Unmarshal(dataBytes, v)
 }
 
+func ReadString(filepath string) (string, error) {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	dataBytes, err := ioutil.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+
+	return string(dataBytes), nil
+	// fmt.Println(dataBytes)
+	// fmt.Println(string(dataBytes))
+
+}
+
 // OverwriteJSON data in the target file with data from the given struct
 //
 // Usage (unstructured):

--- a/internal/initialize/command.go
+++ b/internal/initialize/command.go
@@ -52,7 +52,7 @@ func NewCmdInit(context *cmdcontext.Context) *cobra.Command {
 				return err
 			}
 
-			if project=="" {
+			if project == "" {
 				err = initNewProject(context)
 				if err != nil {
 					return err
@@ -176,7 +176,6 @@ func initExistingProj(project brev_api.Project, context *cmdcontext.Context) err
 	return nil
 }
 
-
 func initNewProject(context *cmdcontext.Context) error {
 
 	// Get Project Name (parent folder-- behavior just like git init)
@@ -189,7 +188,6 @@ func initNewProject(context *cmdcontext.Context) error {
 	dirs := strings.Split(cwd, "/")
 	projName := dirs[len(dirs)-1]
 	fmt.Println(projName)
-
 
 	// Create new project
 	token, _ := auth.GetToken()
@@ -213,9 +211,8 @@ func initNewProject(context *cmdcontext.Context) error {
 		return err
 	}
 
-
 	// TODO: create shared code module
-	
+
 	// Add to path
 	var currBrevDirectories []string
 	err = files.ReadJSON(files.GetActiveProjectsPath(), &currBrevDirectories)

--- a/internal/sync/command.go
+++ b/internal/sync/command.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/brevdev/brev-go-cli/internal/auth"
 	"github.com/brevdev/brev-go-cli/internal/brev_api"
 	"github.com/brevdev/brev-go-cli/internal/brev_ctx"
 	"github.com/brevdev/brev-go-cli/internal/cmdcontext"
@@ -31,15 +30,6 @@ import (
 func push(context *cmdcontext.Context) error {
 
 	// TODO: push module/shared code
-
-	token, err := auth.GetToken()
-	if err != nil {
-		context.PrintErr("", err)
-		return err
-	}
-	brevAgent := brev_api.Agent{
-		Key: token,
-	}
 
 	brevCtx, err := brev_ctx.New()
 	if err != nil {
@@ -62,11 +52,14 @@ func push(context *cmdcontext.Context) error {
 	for _, v := range endpoints {
 		fmt.Fprintf(context.VerboseOut, "\nUpdating ep %s", v.Name)
 
-		brevAgent.UpdateEndpoint(v.Id, brev_api.RequestUpdateEndpoint{
+		fmt.Println(v.Code)
+
+		brevCtx.Remote.SetEndpoint(brev_api.Endpoint{
 			Name:    v.Name,
 			Methods: v.Methods,
 			Code:    v.Code,
 		})
+
 	}
 
 	return nil

--- a/internal/sync/command.go
+++ b/internal/sync/command.go
@@ -61,11 +61,11 @@ func push(context *cmdcontext.Context) error {
 
 	for _, v := range endpoints {
 		fmt.Fprintf(context.VerboseOut, "\nUpdating ep %s", v.Name)
-		
+
 		brevAgent.UpdateEndpoint(v.Id, brev_api.RequestUpdateEndpoint{
-			Name: v.Name,
+			Name:    v.Name,
 			Methods: v.Methods,
-			Code: v.Code,
+			Code:    v.Code,
 		})
 	}
 
@@ -103,14 +103,14 @@ func pull(context *cmdcontext.Context) error {
 	if err != nil {
 		return err
 	}
-	
-	var path string;
+
+	var path string
 	for _, v := range paths {
 		if strings.Contains(cwd, v) {
 			path = v
 		}
 	}
-	if path=="" {
+	if path == "" {
 		return errors.New("this is not a Brev directory")
 	}
 

--- a/internal/sync/command.go
+++ b/internal/sync/command.go
@@ -61,8 +61,6 @@ func push(context *cmdcontext.Context) error {
 			return err
 		}
 
-		fmt.Println(v.Code)
-
 		brevCtx.Remote.SetEndpoint(brev_api.Endpoint{
 			Id:      v.Id,
 			Name:    v.Name,


### PR DESCRIPTION
Making sure we use the context in all the commands. The only two commands that do not use context are `env remove` and `package remove` since the context didn't yet support it.